### PR TITLE
Make top-level supervisor explicit.

### DIFF
--- a/lib/timelier.ex
+++ b/lib/timelier.ex
@@ -74,20 +74,7 @@ defmodule Timelier do
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
-    # Define workers and child supervisors to be supervised
-    children = [
-      supervisor(Timelier.Task.Supervisor, []),
-      worker(Timelier.Server, []),
-      worker(Timelier.Timer, [])
-      # Starts a worker by calling: Timelier.Worker.start_link(arg1, arg2, arg3)
-
-      # worker(Timelier.Worker, [arg1, arg2, arg3]),
-    ]
-
-    # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
-    # for other strategies and supported options
-    opts = [strategy: :rest_for_one, name: Timelier.Supervisor]
-    Supervisor.start_link(children, opts)
+    Timelier.Supervisor.start_link()
   end
 
 

--- a/lib/timelier/supervisor.ex
+++ b/lib/timelier/supervisor.ex
@@ -1,0 +1,20 @@
+defmodule Timelier.Supervisor do
+  use Supervisor
+  @moduledoc false
+
+  @name Timelier.Supervisor
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, [], name: @name)
+  end
+
+  def init([]) do
+    children = [
+      supervisor(Timelier.Task.Supervisor, []),
+      worker(Timelier.Server, []),
+      worker(Timelier.Timer, [])
+    ]
+
+    supervise(children, strategy: :rest_for_one)
+  end
+end


### PR DESCRIPTION
This change allows the timelier supervision tree to be embedded within another
as part of an included application.